### PR TITLE
JSON.parse error because https stream closes too soon

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -25,6 +25,7 @@ Client.prototype.apiCall = function(method, path, params, callback) {
     }
     else if (qs) {
         path += '?' + qs;
+
     }
 
     var req = https.request({
@@ -33,9 +34,14 @@ Client.prototype.apiCall = function(method, path, params, callback) {
         'path': path,
         'headers': headers,
     }, function(res) {
+        var buffer = '';
         res.setEncoding('utf8');
         res.on('data', function (data) {
-            callback(data);
+            buffer = buffer + data;
+        });
+
+        res.on('end', function (data) {
+            callback(buffer);
         });
     });
     req.write(body);


### PR DESCRIPTION
Added listener for 'end of stream' event.  The current code failed on multiple requests because it prematurely sends the response to the callback, and JSON.parse is called on an incomplete json document.  Adding the 'end' event listener keeps the connection open until the entire document is received.