### PR TITLE
Get rid of locale-aware query string param sorting

### DIFF
--- a/lib/duo_sig.js
+++ b/lib/duo_sig.js
@@ -4,11 +4,7 @@ var crypto = require('crypto');
 // a single string or an Array of strings, return the
 // application/x-www-form-urlencoded parameters string.
 function canonParams(params) {
-    // "foo" must sort before "foo_bar" regardless of locale.
-    var ks = Object.keys(params);
-    ks.sort(function(a, b) {
-        return a.localeCompare(b, 'C');
-    });
+    var ks = Object.keys(params).sort();
 
     // Build application/x-www-form-urlencoded string.
     var qs = ks.map(function(k) {

--- a/lib/duo_sig.js
+++ b/lib/duo_sig.js
@@ -1,10 +1,37 @@
 var crypto = require('crypto');
 
+// Compare two strings based on character unicode values.
+//
+// If a string is a subset of another, it should sort before.
+// i.e. 'foo' < 'foo_bar'
+function compare(a, b) {
+    var aChar, bChar;
+
+    for (var i = 0; i < Math.min(a.length, b.length); i++) {
+        aChar = a.charCodeAt(i);
+        bChar = b.charCodeAt(i);
+
+        if (aChar < bChar) {
+            return -1;
+        } else if (aChar > bChar) {
+            return 1;
+        }
+    }
+
+    if (a.length < b.length) {
+        return -1;
+    } else if (a.length > b.length) {
+        return 1;
+    }
+
+    return 0;
+}
+
 // Given an Object mapping from parameter name to its value as either
 // a single string or an Array of strings, return the
 // application/x-www-form-urlencoded parameters string.
 function canonParams(params) {
-    var ks = Object.keys(params).sort();
+    var ks = Object.keys(params).sort(compare);
 
     // Build application/x-www-form-urlencoded string.
     var qs = ks.map(function(k) {

--- a/tests/duo_sig.js
+++ b/tests/duo_sig.js
@@ -92,6 +92,17 @@ module.exports['Query Parameter Checks'] = {
             'foo=1&foo_bar=2'
         );
         test.done();
+    },
+
+    'sort order with real-world common prefix': function(test) {
+        test.equals(
+            duo_api.canonParams({
+                'ip_whitelist_enroll_policy': '2',
+                'ip_whitelist': '1',
+            }),
+            'ip_whitelist=1&ip_whitelist_enroll_policy=2'
+        );
+        test.done();
     }
 };
 


### PR DESCRIPTION
Fixes #3 and the busted tests.  I'm confident this will work 99% of the time.  I'm not sure why this used locale-based sorting in the first place, but I wonder how often '䚚⡻㗐軳朧倪ࠐ킑È셰' will be used as a query parameter name?