### PR TITLE
Updated node version support.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,6 @@
         "promise"
     ],
     "rules": {
-        "camelcase": "off",
-        "node/no-deprecated-api": "off"
+        "camelcase": "off"
     }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 node_js:
-    - "4"
-    - "5"
     - "6"
     - "7"
     - "8"
+    - "9"
+    - "10"
     - "node"
 before_install:
     - npm install

--- a/lib/duo_sig.js
+++ b/lib/duo_sig.js
@@ -72,11 +72,7 @@ function sign (ikey, skey, method, host, path, params, date) {
     .update(canon)
     .digest('hex')
 
-  /**
-   * Move to Buffer.from and remove no-deprecated-api
-   * lint exception when we remove Node v4 support
-   */
-  var auth = new Buffer([ikey, sig].join(':')).toString('base64')
+  var auth = Buffer.from([ikey, sig].join(':')).toString('base64')
   return 'Basic ' + auth
 }
 


### PR DESCRIPTION
Summary:
Node4 has been EOL'd: https://github.com/nodejs/Release.
This diff removes node v4 and 5 from the traviscli build, and adds
node v9 and 10, allowing us to use newer features and thus write
 more efficient, effective, and clean code. This decision warrants
 discussion as it comes at the cost of no longer supporting node4 and node5.