### PR TITLE
Changed duo_api to a scoped module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ $ npm install
 System:
 
 ```
-$ npm install global duo_api
+$ npm install global @duosecurity/duo_api
 ```
 
 Or run the following to add to your project:
 
 ```
-$ npm install --save duo_api
+$ npm install --save @duosecurity/duo_api
 ```
 
 # Using
@@ -57,11 +57,10 @@ OK: 10 assertions (12ms)
 ```
 $ npm run lint
 
-> duo_api@1.0.0 lint duo_api_nodejs
+> @duosecurity/duo_api@1.0.0 lint duo_api_nodejs
 > eslint lib/ tests/
 ```
 
 # Support
 
 Report any bugs, feature requests, etc. to us directly: support@duosecurity.com
-

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "duo_api",
+    "name": "@duosecurity/duo_api",
     "version": "1.0.0",
     "license": "BSD-3-Clause",
     "description": "Duo API SDK for Node.js applications",


### PR DESCRIPTION
Duo_api is now under the duosecurity scope. This allows us to publish our scope to npm, and thus allow users to download duo_api via npm.