### PR TITLE
Added sha512 into the duo_api_nodejs code base

### DIFF
--- a/lib/duo_sig.js
+++ b/lib/duo_sig.js
@@ -65,10 +65,10 @@ function canonicalize (method, host, path, params, date) {
   ].join('\n')
 }
 
-// Return the Authorization header for an HMAC-SHA1-signed request.
-function sign (ikey, skey, method, host, path, params, date) {
+// Return the Authorization header for an HMAC signed request.
+function sign (ikey, skey, method, host, path, params, date, digestmod = 'sha1') {
   var canon = canonicalize(method, host, path, params, date)
-  var sig = crypto.createHmac('sha1', skey)
+  var sig = crypto.createHmac(digestmod, skey)
     .update(canon)
     .digest('hex')
 

--- a/tests/duo_sig.js
+++ b/tests/duo_sig.js
@@ -124,5 +124,45 @@ module.exports['Signature Checks'] = {
     )
     test.equals(actual, 'Basic dGVzdF9pa2V5OmYwMTgxMWNiYmY5NTYxNjIzYWI0NWI4OTMwOTYyNjdmZDQ2YTUxNzg=')
     test.done()
+  },
+
+  'HMAC-SHA1-parameter': function (test) {
+    var actual = duo_api.sign(
+      'test_ikey',
+      'gtdfxv9YgVBYcF6dl2Eq17KUQJN2PLM2ODVTkvoT',
+      'PoSt',
+      'foO.BAr52.cOm',
+      '/Foo/BaR2/qux',
+      {
+        '\u469a\u287b\u35d0\u8ef3\u6727\u502a\u0810\ud091\xc8\uc170': ['\u0f45\u1a76\u341a\u654c\uc23f\u9b09\uabe2\u8343\u1b27\u60d0'],
+        '\u7449\u7e4b\uccfb\u59ff\ufe5f\u83b7\uadcc\u900c\ucfd1\u7813': ['\u8db7\u5022\u92d3\u42ef\u207d\u8730\uacfe\u5617\u0946\u4e30'],
+        '\u7470\u9314\u901c\u9eae\u40d8\u4201\u82d8\u8c70\u1d31\ua042': ['\u17d9\u0ba8\u9358\uaadf\ua42a\u48be\ufb96\u6fe9\ub7ff\u32f3'],
+        '\uc2c5\u2c1d\u2620\u3617\u96b3F\u8605\u20e8\uac21\u5934': ['\ufba9\u41aa\ubd83\u840b\u2615\u3e6e\u652d\ua8b5\ud56bU']
+      },
+      'Fri, 07 Dec 2012 17:18:00 -0000',
+      'sha1'
+    )
+    test.equals(actual, 'Basic dGVzdF9pa2V5OmYwMTgxMWNiYmY5NTYxNjIzYWI0NWI4OTMwOTYyNjdmZDQ2YTUxNzg=')
+    test.done()
+  },
+
+  'HMAC-SHA512-parameter': function (test) {
+    var actual = duo_api.sign(
+      'test_ikey',
+      'gtdfxv9YgVBYcF6dl2Eq17KUQJN2PLM2ODVTkvoT',
+      'PoSt',
+      'foO.BAr52.cOm',
+      '/Foo/BaR2/qux',
+      {
+        '\u469a\u287b\u35d0\u8ef3\u6727\u502a\u0810\ud091\xc8\uc170': ['\u0f45\u1a76\u341a\u654c\uc23f\u9b09\uabe2\u8343\u1b27\u60d0'],
+        '\u7449\u7e4b\uccfb\u59ff\ufe5f\u83b7\uadcc\u900c\ucfd1\u7813': ['\u8db7\u5022\u92d3\u42ef\u207d\u8730\uacfe\u5617\u0946\u4e30'],
+        '\u7470\u9314\u901c\u9eae\u40d8\u4201\u82d8\u8c70\u1d31\ua042': ['\u17d9\u0ba8\u9358\uaadf\ua42a\u48be\ufb96\u6fe9\ub7ff\u32f3'],
+        '\uc2c5\u2c1d\u2620\u3617\u96b3F\u8605\u20e8\uac21\u5934': ['\ufba9\u41aa\ubd83\u840b\u2615\u3e6e\u652d\ua8b5\ud56bU']
+      },
+      'Fri, 07 Dec 2012 17:18:00 -0000',
+      'sha512'
+    )
+    test.equals(actual, 'Basic dGVzdF9pa2V5OjA1MDgwNjUwMzVhMDNiMmExZGUyZjQ1M2U2MjllNzkxZDE4MDMyOWUxNTdmNjVkZjZiM2UwZjA4Mjk5ZDQzMjFlMWM1YzdhN2M3ZWU2YjllNWZjODBkMWZiNmZiZjNhZDVlYjdjNDRkZDNiMzk4NWEwMmMzN2FjYTUzZWMzNjk4')
+    test.done()
   }
 }


### PR DESCRIPTION
Summary: The new Web SDK protocol must not use SHA-1 or HMAC-SHA1 for any security features. This diff gives adds an optional paramater to the 'sign' function, adding the ability to use SHA512 without breaking the current flow.