### PR TITLE
Add backoff and retry when a request is rate limited

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,12 @@ var duo_sig = require('./duo_sig')
 var https = require('https')
 var querystring = require('querystring')
 
+// Constants for handling rate limit backoff and retries
+const _MAX_BACKOFF_WAIT_SECS = 32
+const _INITIAL_BACKOFF_WAIT_SECS = 1
+const _BACKOFF_FACTOR = 2
+const _RATE_LIMITED_RESP_CODE = 429
+
 function Client (ikey, skey, host, sig_version = 2) {
   this.ikey = ikey
   this.skey = skey
@@ -12,6 +18,7 @@ function Client (ikey, skey, host, sig_version = 2) {
 }
 
 Client.prototype.apiCall = function (method, path, params, callback) {
+
   var date = new Date().toUTCString()
   var headers = {
     'Date': date,
@@ -35,12 +42,26 @@ Client.prototype.apiCall = function (method, path, params, callback) {
     path += '?' + qs
   }
 
-  var req = https.request({
+  const options = {
     'host': this.host,
     'method': method,
     'path': path,
     'headers': headers
-  }, function (res) {
+  }
+  _request_with_backoff(options, body, callback)
+}
+
+function _request_with_backoff (options, body, callback, waitSecs = 1) {
+  var req = https.request(options, function (res) {
+    if (res.statusCode === _RATE_LIMITED_RESP_CODE &&
+        waitSecs <= _MAX_BACKOFF_WAIT_SECS) {
+        randomOffset = Math.floor(Math.random() * 1000);
+        setTimeout(function() {
+            _request_with_backoff(options, body, callback, waitSecs * _BACKOFF_FACTOR)
+        }, waitSecs * 1000 + randomOffset)
+        return
+    }
+
     var buffer = ''
     res.setEncoding('utf8')
     res.on('data', function (data) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,7 +4,6 @@ var querystring = require('querystring')
 
 // Constants for handling rate limit backoff and retries
 const _MAX_BACKOFF_WAIT_SECS = 32
-const _INITIAL_BACKOFF_WAIT_SECS = 1
 const _BACKOFF_FACTOR = 2
 const _RATE_LIMITED_RESP_CODE = 429
 
@@ -18,7 +17,6 @@ function Client (ikey, skey, host, sig_version = 2) {
 }
 
 Client.prototype.apiCall = function (method, path, params, callback) {
-
   var date = new Date().toUTCString()
   var headers = {
     'Date': date,
@@ -54,12 +52,12 @@ Client.prototype.apiCall = function (method, path, params, callback) {
 function _request_with_backoff (options, body, callback, waitSecs = 1) {
   var req = https.request(options, function (res) {
     if (res.statusCode === _RATE_LIMITED_RESP_CODE &&
-        waitSecs <= _MAX_BACKOFF_WAIT_SECS) {
-        randomOffset = Math.floor(Math.random() * 1000);
-        setTimeout(function() {
-            _request_with_backoff(options, body, callback, waitSecs * _BACKOFF_FACTOR)
-        }, waitSecs * 1000 + randomOffset)
-        return
+      waitSecs <= _MAX_BACKOFF_WAIT_SECS) {
+      var randomOffset = Math.floor(Math.random() * 1000)
+      setTimeout(function () {
+        _request_with_backoff(options, body, callback, waitSecs * _BACKOFF_FACTOR)
+      }, waitSecs * 1000 + randomOffset)
+      return
     }
 
     var buffer = ''

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@duosecurity/duo_api",
-    "version": "1.0.1",
+    "version": "1.2.0",
     "license": "BSD-3-Clause",
     "description": "Duo API SDK for Node.js applications",
     "homepage": "https://www.duosecurity.com/api",
@@ -21,7 +21,8 @@
         "eslint-plugin-promise": "^3.7.0",
         "eslint-plugin-standard": "^3.0.1",
         "mocha": "^5.2.0",
-        "nock": "^9.6.1"
+        "nock": "^9.6.1",
+        "sinon": "^7.2.7"
     },
     "optionalDependencies": {
         "nopt": ">= 2.1.2"

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,3 +1,4 @@
+/* global describe it beforeEach afterEach */
 var assert = require('assert')
 var nock = require('nock')
 var sinon = require('sinon')
@@ -21,11 +22,11 @@ describe('Verifying rate limited request retries', function () {
     client = new duo_api.Client(IKEY, SKEY, API_HOSTNAME)
   })
 
-  afterEach(function() {
+  afterEach(function () {
     clock.restore()
   })
 
-  function addRequests(statusCode, numRequests = 1) {
+  function addRequests (statusCode, numRequests = 1) {
     var stat = statusCode === OK_RESP_CODE ? 'OK' : 'FAIL'
     var date = new Date().toUTCString()
     var path = '/foo/bar'
@@ -53,37 +54,37 @@ describe('Verifying rate limited request retries', function () {
   })
 
   it('verify single rate limited response', function (done) {
-    let currentWaitSecs = 1000;
+    let currentWaitSecs = 1000
     var rateLimitedScope = addRequests(RATE_LIMITED_RESP_CODE)
     addRequests(OK_RESP_CODE)
     client.jsonApiCall('GET', '/foo/bar', {}, function (resp) {
       assert.equal(resp.stat, 'OK')
       done()
     })
-    
+
     // Don't tick the clock until after the request has been replied to,
     // otherwise we'll move the clock forward before adding the retry attempt
     // via setTimeout.
-    rateLimitedScope.on('replied', function(req, interceptor) {
-      clock.tick(currentWaitSecs + MAX_RANDOM_OFFSET);
+    rateLimitedScope.on('replied', function (req, interceptor) {
+      clock.tick(currentWaitSecs + MAX_RANDOM_OFFSET)
     })
     console.log('added emitter')
   })
-  
-  it('verify all rate limited responses', function(done) {
-    var currentWaitSecs = 1000;
+
+  it('verify all rate limited responses', function (done) {
+    var currentWaitSecs = 1000
     var scope = addRequests(RATE_LIMITED_RESP_CODE, 7)
 
     client.jsonApiCall('GET', '/foo/bar', {}, function (resp) {
       assert.equal(resp.stat, 'FAIL')
       done()
     })
-    
+
     // Don't tick the clock until after the request has been replied to,
     // otherwise we'll move the clock forward before adding the retry attempt
     // via setTimeout.
-    scope.on('replied', function(req, interceptor) {
-      clock.tick(currentWaitSecs + MAX_RANDOM_OFFSET);
+    scope.on('replied', function (req, interceptor) {
+      clock.tick(currentWaitSecs + MAX_RANDOM_OFFSET)
       currentWaitSecs = currentWaitSecs * BACKOFF_FACTOR
     })
   })

--- a/tests/main.js
+++ b/tests/main.js
@@ -1,0 +1,90 @@
+var assert = require('assert')
+var nock = require('nock')
+var sinon = require('sinon')
+var duo_api = require('../lib/main.js')
+var duo_sig = require('../lib/duo_sig')
+
+var IKEY = 'DIXXXXXXXXXXXXXXXXXX'
+var SKEY = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+var API_HOSTNAME = 'api_hostname'
+
+describe('Verifying rate limited request retries', function () {
+  var MAX_RANDOM_OFFSET = 1000
+  var BACKOFF_FACTOR = 2
+  var OK_RESP_CODE = 200
+  var RATE_LIMITED_RESP_CODE = 429
+  var clock
+  var client
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers()
+    client = new duo_api.Client(IKEY, SKEY, API_HOSTNAME)
+  })
+
+  afterEach(function() {
+    clock.restore()
+  })
+
+  function addRequests(statusCode, numRequests = 1) {
+    var stat = statusCode === OK_RESP_CODE ? 'OK' : 'FAIL'
+    var date = new Date().toUTCString()
+    var path = '/foo/bar'
+    var sig = duo_sig.sign(
+      client.ikey, client.skey, 'GET', client.host, path, {}, date, client.sig_version, client.digestmod)
+    var scope = nock('https://' + API_HOSTNAME, {
+      reqheaders: {
+        'Date': date,
+        'Host': API_HOSTNAME,
+        'Authorization': sig
+      }
+    })
+    scope.get(path)
+      .times(numRequests)
+      .reply(statusCode, {'response': {foo: 'bar'}, stat})
+    return scope
+  }
+
+  it('verify does not sleep on ok resp', function (done) {
+    addRequests(OK_RESP_CODE)
+    client.jsonApiCall('GET', '/foo/bar', {}, function (resp) {
+      assert.equal(resp.stat, 'OK')
+      done()
+    })
+  })
+
+  it('verify single rate limited response', function (done) {
+    let currentWaitSecs = 1000;
+    var rateLimitedScope = addRequests(RATE_LIMITED_RESP_CODE)
+    addRequests(OK_RESP_CODE)
+    client.jsonApiCall('GET', '/foo/bar', {}, function (resp) {
+      assert.equal(resp.stat, 'OK')
+      done()
+    })
+    
+    // Don't tick the clock until after the request has been replied to,
+    // otherwise we'll move the clock forward before adding the retry attempt
+    // via setTimeout.
+    rateLimitedScope.on('replied', function(req, interceptor) {
+      clock.tick(currentWaitSecs + MAX_RANDOM_OFFSET);
+    })
+    console.log('added emitter')
+  })
+  
+  it('verify all rate limited responses', function(done) {
+    var currentWaitSecs = 1000;
+    var scope = addRequests(RATE_LIMITED_RESP_CODE, 7)
+
+    client.jsonApiCall('GET', '/foo/bar', {}, function (resp) {
+      assert.equal(resp.stat, 'FAIL')
+      done()
+    })
+    
+    // Don't tick the clock until after the request has been replied to,
+    // otherwise we'll move the clock forward before adding the retry attempt
+    // via setTimeout.
+    scope.on('replied', function(req, interceptor) {
+      clock.tick(currentWaitSecs + MAX_RANDOM_OFFSET);
+      currentWaitSecs = currentWaitSecs * BACKOFF_FACTOR
+    })
+  })
+})


### PR DESCRIPTION
If the request is rate limited, this library will now sleep for
a bit and then try again. We use an exponential backoff, so the
request should sleep for 1 second, then 2, then 4, 8, 16, and max
out at 32 seconds.

Also add sinon as a dev dependency and bump the minor version number.