### PR TITLE
Error handling added

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -70,6 +70,9 @@ function _request_with_backoff (options, body, callback, waitSecs = 1) {
       callback(buffer)
     })
   })
+  req.on('error', (err) => {
+    callback(JSON.stringify({ stat: 'ERROR', message: err.message })
+  })
   req.write(body)
   req.end()
 }


### PR DESCRIPTION
In  the event of a timeout or other non 200 http code response the request error will now be caught and formatted similarly to the response block ( `{  stat: 'OK', ...}` ) and returned through the callback.

I have tested this code in our system and it does properly handle timeouts. A caught error will look like this:

```javascript
{
  stat: 'ERROR',
  message: 'Some error message taken from the caught Error object'
}
```

This fix will take care of issue #19 