### PR TITLE
New Feature: jsonApiCallAsync

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -83,6 +83,24 @@ Client.prototype.jsonApiCall = function (method, path, params, callback) {
   })
 }
 
+/**
+ * Same as jsonApiCall except a promise is returned instead of using
+ * a callback. If the stat field of the response does not equal OK
+ * then an error will be throw for handling.
+ * @param method HTTP Method GET | POST | DELETE | PUT
+ * @param path Duo API path to to which the request is made
+ * @param params JSON object containing parameters for the request
+ */
+Client.prototype.jsonApiCallAsync = function (method, path, params) {
+  return new Promise((resolve, reject) => {
+    this.apiCall(method, path, params, function (data) {
+      data = JSON.parse(data)
+      if (data.stat === 'OK') return resolve(data)
+      else return reject(new Error(data.message))
+    })
+  })
+}
+
 module.exports = {
   'Client': Client
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -7,7 +7,7 @@ const _MAX_BACKOFF_WAIT_SECS = 32
 const _BACKOFF_FACTOR = 2
 const _RATE_LIMITED_RESP_CODE = 429
 
-function Client (ikey, skey, host, sig_version = 2) {
+function Client(ikey, skey, host, sig_version = 2) {
   this.ikey = ikey
   this.skey = skey
   this.host = host
@@ -49,7 +49,7 @@ Client.prototype.apiCall = function (method, path, params, callback) {
   _request_with_backoff(options, body, callback)
 }
 
-function _request_with_backoff (options, body, callback, waitSecs = 1) {
+function _request_with_backoff(options, body, callback, waitSecs = 1) {
   var req = https.request(options, function (res) {
     if (res.statusCode === _RATE_LIMITED_RESP_CODE &&
       waitSecs <= _MAX_BACKOFF_WAIT_SECS) {

--- a/package.json
+++ b/package.json
@@ -1,45 +1,45 @@
 {
-    "name": "@duosecurity/duo_api",
-    "version": "1.2.0",
-    "license": "BSD-3-Clause",
-    "description": "Duo API SDK for Node.js applications",
-    "homepage": "https://www.duosecurity.com/api",
-    "main": "lib/main.js",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/duosecurity/duo_api_nodejs.git"
-    },
-    "scripts": {
-        "test": "./node_modules/mocha/bin/mocha ./tests/*",
-        "lint": "eslint lib/ tests/"
-    },
-    "devDependencies": {
-        "eslint": "^4.18.2",
-        "eslint-config-standard": "^11.0.0",
-        "eslint-plugin-import": "^2.8.0",
-        "eslint-plugin-node": "^5.2.1",
-        "eslint-plugin-promise": "^3.7.0",
-        "eslint-plugin-standard": "^3.0.1",
-        "mocha": "^5.2.0",
-        "nock": "^9.6.1",
-        "sinon": "^7.2.7"
-    },
-    "optionalDependencies": {
-        "nopt": ">= 2.1.2"
-    },
-    "dependencies": {},
-    "keywords": [
-        "Duo Security",
-        "Two-Factor Authentication"
-    ],
-    "readmeFilename": "README.md",
-    "bugs": {
-        "url": "https://www.duosecurity.com/support"
-    },
-    "licenses": [
-        {
-            "type": "Duo License",
-            "url": "https://github.com/duosecurity/duo_api_nodejs/blob/master/LICENSE"
-        }
-    ]
+  "name": "@duosecurity/duo_api",
+  "version": "1.3.0",
+  "license": "BSD-3-Clause",
+  "description": "Duo API SDK for Node.js applications",
+  "homepage": "https://www.duosecurity.com/api",
+  "main": "lib/main.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/duosecurity/duo_api_nodejs.git"
+  },
+  "scripts": {
+    "test": "node_modules/mocha/bin/mocha ./tests/*",
+    "lint": "eslint lib/ tests/"
+  },
+  "devDependencies": {
+    "eslint": "^4.18.2",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-node": "^5.2.1",
+    "eslint-plugin-promise": "^3.7.0",
+    "eslint-plugin-standard": "^3.0.1",
+    "mocha": "^5.2.0",
+    "nock": "^9.6.1",
+    "sinon": "^7.2.7"
+  },
+  "optionalDependencies": {
+    "nopt": ">= 2.1.2"
+  },
+  "dependencies": {},
+  "keywords": [
+    "Duo Security",
+    "Two-Factor Authentication"
+  ],
+  "readmeFilename": "README.md",
+  "bugs": {
+    "url": "https://www.duosecurity.com/support"
+  },
+  "licenses": [
+    {
+      "type": "Duo License",
+      "url": "https://github.com/duosecurity/duo_api_nodejs/blob/master/LICENSE"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/duosecurity/duo_api_nodejs.git"
   },
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha ./tests/*",
+    "test": "./node_modules/mocha/bin/mocha ./tests/*",
     "lint": "eslint lib/ tests/"
   },
   "devDependencies": {

--- a/tests/main.js
+++ b/tests/main.js
@@ -26,7 +26,7 @@ describe('Verifying rate limited request retries', function () {
     clock.restore()
   })
 
-  function addRequests (statusCode, numRequests = 1) {
+  function addRequests(statusCode, numRequests = 1) {
     var stat = statusCode === OK_RESP_CODE ? 'OK' : 'FAIL'
     var date = new Date().toUTCString()
     var path = '/foo/bar'
@@ -41,7 +41,7 @@ describe('Verifying rate limited request retries', function () {
     })
     scope.get(path)
       .times(numRequests)
-      .reply(statusCode, {'response': {foo: 'bar'}, stat})
+      .reply(statusCode, { 'response': { foo: 'bar' }, stat })
     return scope
   }
 


### PR DESCRIPTION
- Provided a new function that wraps the existing jsonApiCall function in a Promise object
- This allows for easy call().then().catch().finally() or async/await syntax to be used out of the box
- Leverages existing code so this is mostly "syntactic sugar"
- Properly throws with Promise rejection when stat code is not `'OK'`
- Included two new unit tests structure like the existing jsonApiCall tests, but using the Promise syntax instead
- Incremented the minor version to 1.3.0 since this is a new feature that does not break backward compatibility.