### PR TITLE
Escape repeating characters not included as part of encodeURIComponent

### DIFF
--- a/lib/duo_sig.js
+++ b/lib/duo_sig.js
@@ -48,11 +48,11 @@ function canonParams (params) {
   // encodeURIComponent doesn't escape all needed characters.
   // We need to use global regexps to handle the remaining cases.
 
-  var exclamationRegexp = /!/g; 
-  var singleQuoteRegexp = /'/g;
-  var lparenRegexp = /\(/g;
-  var rparenRegexp = /\)/g;
-  var starRegexp = /\*/g;
+  var exclamationRegexp = /!/g
+  var singleQuoteRegexp = /'/g
+  var lparenRegexp = /\(/g
+  var rparenRegexp = /\)/g
+  var starRegexp = /\*/g
   return qs
     .replace(exclamationRegexp, '%21')
     .replace(singleQuoteRegexp, '%27')

--- a/lib/duo_sig.js
+++ b/lib/duo_sig.js
@@ -46,12 +46,19 @@ function canonParams (params) {
   }).join('&')
 
   // encodeURIComponent doesn't escape all needed characters.
+  // We need to use global regexps to handle the remaining cases.
+
+  var exclamationRegexp = /!/g; 
+  var singleQuoteRegexp = /'/g;
+  var lparenRegexp = /\(/g;
+  var rparenRegexp = /\)/g;
+  var starRegexp = /\*/g;
   return qs
-    .replace('!', '%21')
-    .replace("'", '%27')
-    .replace('(', '%28')
-    .replace(')', '%29')
-    .replace('*', '%2A')
+    .replace(exclamationRegexp, '%21')
+    .replace(singleQuoteRegexp, '%27')
+    .replace(lparenRegexp, '%28')
+    .replace(rparenRegexp, '%29')
+    .replace(starRegexp, '%2A')
 }
 
 // Return a request's canonical representation as a string to sign.

--- a/tests/duo_sig.js
+++ b/tests/duo_sig.js
@@ -53,6 +53,17 @@ describe('Query Parameter Checks', function () {
     done()
   })
 
+  it('repeating special ascii characters', function (done) {
+    assert.equal(
+      duo_api._canonParams({
+        'punctuation': ['!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'],
+        'again': ['!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'],
+      }),
+      'again=%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D~&punctuation=%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D~'
+    )
+    done()
+  })
+
   it('unicode fuzz values', function (done) {
     assert.equal(
       duo_api._canonParams({

--- a/tests/duo_sig.js
+++ b/tests/duo_sig.js
@@ -57,7 +57,7 @@ describe('Query Parameter Checks', function () {
     assert.equal(
       duo_api._canonParams({
         'punctuation': ['!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'],
-        'again': ['!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~'],
+        'again': ['!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~']
       }),
       'again=%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D~&punctuation=%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D~'
     )


### PR DESCRIPTION
canonParams() is responsible for doing a x-www-form-urlencoded encoding of an object.

In addition to a series of encodeURIComponent calls, there were a few uses of .replace() being used to replace certain characters. However, .replace() with a string argument will only replace the *first* instance of that character. If you want to replace all characters, you must use a regexp with a global flag.

LGTM reported this https://lgtm.com/projects/g/duosecurity/duo_api_nodejs

I have added test cases to confirm the (what I assume is) incorrect behavior. I've also provided a fix.