### PR TITLE
Added option to call the api with Promises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 node_js:
-    - "6"
-    - "7"
-    - "8"
-    - "9"
     - "10"
+    - "12"
+    - "14"
     - "node"
 before_install:
     - npm install

--- a/lib/main.js
+++ b/lib/main.js
@@ -77,6 +77,41 @@ Client.prototype.jsonApiCall = function (method, path, params, callback) {
   })
 }
 
+/**
+ * Works just like the jsonApiCall function, but instead returns a Promise
+ * that will throw when the "stat" field does not equal "OK"
+ * @param {"GET"|"PUT"|"POST"|"DELETE"} method The HTTP method to use for the request
+ * @param {string} path The url path for the request
+ * @param {Object} params JSON object that contains the key/values for POST/PUT requests or queryparams for GET requests
+ * @returns {Object} A JSON object representing the response (JSON.parse called on the returned string)
+ */
+Client.prototype.jsonApiCallAsync = function (method, path, params) {
+  return new Promise((resolve, reject) => {
+    this.jsonApiCall(method, path, params, (data) => {
+      if (data.stat === 'OK') return resolve(data)
+      else return reject(new Error(data.message))
+    })
+  })
+}
+
+/**
+ * Works just like the jsonApiCall function, but instead returns a Promise
+ * that will throw when the "stat" field does not equal "OK"
+ * @param {"GET"|"PUT"|"POST"|"DELETE"} method The HTTP method to use for the request
+ * @param {string} path The url path for the request
+ * @param {Object} params JSON object that contains the key/values for POST/PUT requests or queryparams for GET requests
+ * @returns {string} The raw string response from the API
+ */
+Client.prototype.apiCallAsync = function (method, path, params) {
+  return new Promise((resolve, reject) => {
+    this.apiCall(method, path, params, (dataString) => {
+      let temp = JSON.parse(dataString)
+      if (temp.stat === 'OK') return resolve(dataString)
+      else return reject(new Error(temp.message))
+    })
+  })
+}
+
 module.exports = {
   'Client': Client
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@duosecurity/duo_api",
-    "version": "1.2.1",
+    "version": "1.3.0",
     "license": "BSD-3-Clause",
     "description": "Duo API SDK for Node.js applications",
     "homepage": "https://www.duosecurity.com/api",


### PR DESCRIPTION
I closed my previous pull request because it had some  extraneous changes due to some editor formatting differences. This PR does not have that problem. The following has been added:

- `jsonApiCallAsync`: Works just like jsonApiCall but instead of expecting a callback function a Promise object is returned. The promise will resolve when the 'stat' field is 'OK'. It will reject when the 'stat' field is not 'OK'. This makes for better use of Promise patterns like then().catch() and try/catch.
- `apiCallAsync`: Works just like apiCall but returns a Promise following the same pattern as `jsonApiCallAsync`.

This does not touch the existing functionality. In fact it uses it. So these behave exactly the same as the original calls, but with the added convenience of being Promises. These changes will have no effect on those currently using the library (thus the minor version increment instead of major).