### PR TITLE
Disable CI Schedule

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-    - cron: '0 23 * * 1'
     
 jobs:
   node-ci:


### PR DESCRIPTION
Scheduled workflows get disabled after a period of inactivity, which also means they don't run on pushes or CI, which is not great.