### PR TITLE
Add support for v5 signatures

### DIFF
--- a/example/duo_admin_policy.js
+++ b/example/duo_admin_policy.js
@@ -37,7 +37,12 @@ Options:
   }
 }
 
-var client = new duo_api.Client(parsed.ikey, parsed.skey, parsed.host, 5)
+var client = new duo_api.Client(
+  parsed.ikey,
+  parsed.skey,
+  parsed.host,
+  duo_api.SIGNATURE_VERSION_5
+)
 
 let params = {
   'policy_name': 'api_test_policy',

--- a/example/duo_admin_policy.js
+++ b/example/duo_admin_policy.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+var nopt = require('nopt')
+var duo_api = require('../')
+
+var parsed = nopt({
+  'ikey': [String],
+  'skey': [String],
+  'host': [String]
+}, [], process.argv, 2)
+
+var requirements_met = (parsed.ikey && parsed.skey && parsed.host)
+
+if (!requirements_met) {
+  console.error('Missing required option.\n')
+}
+
+if (parsed.help || !requirements_met) {
+  console.log(function () { /*
+Usage:
+
+    duo_admin_policy.js --ikey IKEY --skey SKEY --host HOST
+
+    Example of making one Policy API call against the Duo service.
+
+Options:
+
+    --ikey    Admin API integration key (required)
+    --skey    Corresponding secret key (required)
+    --host    API hostname (required)
+    --help    Print this help.
+*/ }.toString().split(/\n/).slice(1, -1).join('\n'))
+  if (parsed.help) {
+    process.exit(0)
+  } else {
+    process.exit(1)
+  }
+}
+
+var client = new duo_api.Client(parsed.ikey, parsed.skey, parsed.host)
+
+let params = {
+  'policy_name': 'api_test_policy',
+  'sections': {
+    'screen_lock': {
+      'require_screen_lock': false
+    }
+  }
+}
+
+let policy_key = ''
+
+client.jsonApiCall(
+  'POST',
+  '/admin/v2/policies',
+  params,
+  function (res) {
+    if (res.stat !== 'OK') {
+      console.error('API call returned error: ' + res.message)
+      process.exit(1)
+    }
+
+    res = res.response
+    policy_key = res.policy_key
+
+    console.log('res = ' + JSON.stringify(res, null, 4))
+
+    // Delete the created policy
+    deletePolicy(policy_key)
+  },
+  5
+)
+
+// Delete policy function
+function deletePolicy (policy_key) {
+  client.jsonApiCall(
+    'DELETE',
+    '/admin/v2/policies/' + policy_key,
+    {},
+    function (res) {
+      if (res.stat !== 'OK') {
+        console.error('API call returned error: ' + res.message)
+        process.exit(1)
+      }
+      res = res.response
+      console.log('Deleted policy: ' + policy_key)
+    },
+    5
+  )
+}

--- a/example/duo_admin_policy.js
+++ b/example/duo_admin_policy.js
@@ -72,8 +72,7 @@ client.jsonApiCall(
 
     // Delete the created policy
     deletePolicy(policy_key)
-  },
-  5
+  }
 )
 
 // Delete policy function
@@ -89,7 +88,6 @@ function deletePolicy (policy_key) {
       }
       res = res.response
       console.log('Deleted policy: ' + policy_key)
-    },
-    5
+    }
   )
 }

--- a/example/duo_admin_policy.js
+++ b/example/duo_admin_policy.js
@@ -37,7 +37,7 @@ Options:
   }
 }
 
-var client = new duo_api.Client(parsed.ikey, parsed.skey, parsed.host)
+var client = new duo_api.Client(parsed.ikey, parsed.skey, parsed.host, 5)
 
 let params = {
   'policy_name': 'api_test_policy',

--- a/lib/duo_sig.js
+++ b/lib/duo_sig.js
@@ -72,6 +72,18 @@ function canonicalize (method, host, path, params, date) {
   ].join('\n')
 }
 
+function canonicalizeV5 (method, host, path, params, date, body) {
+  return [
+    date,
+    method.toUpperCase(),
+    host.toLowerCase(),
+    path,
+    canonParams(params),
+    hashString(body),
+    hashString('') // additional headers not needed at this time
+  ].join('\n')
+}
+
 // Return the Authorization header for an HMAC signed request.
 function sign (ikey, skey, method, host, path, params, date) {
   var canon = canonicalize(method, host, path, params, date)
@@ -83,8 +95,25 @@ function sign (ikey, skey, method, host, path, params, date) {
   return 'Basic ' + auth
 }
 
+function signV5 (ikey, skey, method, host, path, params, date, body) {
+  var canon = canonicalizeV5(method, host, path, params, date, body)
+  var sig = crypto.createHmac('sha512', skey)
+    .update(canon)
+    .digest('hex')
+
+  var auth = Buffer.from([ikey, sig].join(':')).toString('base64')
+  return 'Basic ' + auth
+}
+
+function hashString (to_hash) {
+  return crypto.createHash('sha512')
+    .update(to_hash)
+    .digest('hex')
+}
+
 module.exports = {
   'sign': sign,
+  'signV5': signV5,
   '_canonParams': canonParams,
   '_canonicalize': canonicalize
 }

--- a/lib/duo_sig.js
+++ b/lib/duo_sig.js
@@ -62,6 +62,7 @@ function canonParams (params) {
 }
 
 // Return a request's canonical representation as a string to sign.
+// Canonicalization format is version 2.
 function canonicalize (method, host, path, params, date) {
   return [
     date,
@@ -72,6 +73,7 @@ function canonicalize (method, host, path, params, date) {
   ].join('\n')
 }
 
+// Canonicalization format is version 5.
 function canonicalizeV5 (method, host, path, params, date, body) {
   return [
     date,
@@ -85,6 +87,7 @@ function canonicalizeV5 (method, host, path, params, date, body) {
 }
 
 // Return the Authorization header for an HMAC signed request.
+// Signature format is version 2.
 function sign (ikey, skey, method, host, path, params, date) {
   var canon = canonicalize(method, host, path, params, date)
   var sig = crypto.createHmac('sha512', skey)
@@ -95,6 +98,7 @@ function sign (ikey, skey, method, host, path, params, date) {
   return 'Basic ' + auth
 }
 
+// Signature format is version 5.
 function signV5 (ikey, skey, method, host, path, params, date, body) {
   var canon = canonicalizeV5(method, host, path, params, date, body)
   var sig = crypto.createHmac('sha512', skey)

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,13 +5,14 @@ var constants = require('./constants')
 
 const _PACKAGE_VERSION = require('../package.json').version
 
-function Client (ikey, skey, host) {
+function Client (ikey, skey, host, sig_version = 2) {
   this.ikey = ikey
   this.skey = skey
   this.host = host
+  this.sig_version = sig_version
 }
 
-Client.prototype.apiCall = function (method, path, params, callback, signature = 2) {
+Client.prototype.apiCall = function (method, path, params, callback) {
   var date = new Date().toUTCString()
   var headers = {
     'Date': date,
@@ -20,7 +21,7 @@ Client.prototype.apiCall = function (method, path, params, callback, signature =
   }
   var body = ''
   var qs = querystring.stringify(params)
-  if (signature === 5) {
+  if (this.sig_version === 5) {
     if (method === 'POST' || method === 'PUT') {
       body = JSON.stringify(params)
       params = {}

--- a/lib/main.js
+++ b/lib/main.js
@@ -86,10 +86,10 @@ function _request_with_backoff (options, body, callback, waitSecs = 1) {
   req.end()
 }
 
-Client.prototype.jsonApiCall = function (method, path, params, callback, signature = 2) {
+Client.prototype.jsonApiCall = function (method, path, params, callback) {
   this.apiCall(method, path, params, function (data) {
     callback(JSON.parse(data))
-  }, signature)
+  })
 }
 
 module.exports = {

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,21 +11,29 @@ function Client (ikey, skey, host) {
   this.host = host
 }
 
-Client.prototype.apiCall = function (method, path, params, callback) {
+Client.prototype.apiCall = function (method, path, params, callback, signature = 2) {
   var date = new Date().toUTCString()
   var headers = {
     'Date': date,
     'Host': this.host,
     'User-Agent': `duo_api_nodejs/${_PACKAGE_VERSION}`
   }
-  headers['Authorization'] = duo_sig.sign(
-    this.ikey, this.skey, method, this.host, path, params, date)
-
-  var qs = querystring.stringify(params)
   var body = ''
+  var qs = querystring.stringify(params)
+  if (signature === 5) {
+    if (method === 'POST' || method === 'PUT') {
+      body = JSON.stringify(params)
+      params = {}
+    }
+    headers['Authorization'] = duo_sig.signV5(
+      this.ikey, this.skey, method, this.host, path, params, date, body)
+  } else {
+    headers['Authorization'] = duo_sig.sign(
+      this.ikey, this.skey, method, this.host, path, params, date)
+  }
+
   if (method === 'POST' || method === 'PUT') {
-    body = qs
-    headers['Content-type'] = 'application/x-www-form-urlencoded'
+    headers['Content-type'] = 'application/json'
   } else if (qs) {
     path += '?' + qs
   }
@@ -68,10 +76,10 @@ function _request_with_backoff (options, body, callback, waitSecs = 1) {
   req.end()
 }
 
-Client.prototype.jsonApiCall = function (method, path, params, callback) {
+Client.prototype.jsonApiCall = function (method, path, params, callback, signature = 2) {
   this.apiCall(method, path, params, function (data) {
     callback(JSON.parse(data))
-  })
+  }, signature)
 }
 
 module.exports = {

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,11 +5,11 @@ var constants = require('./constants')
 
 const _PACKAGE_VERSION = require('../package.json').version
 
-function Client (ikey, skey, host, sig_version = 2) {
+function Client (ikey, skey, host, sigVersion = 2) {
   this.ikey = ikey
   this.skey = skey
   this.host = host
-  this.sig_version = sig_version
+  this.sigVersion = sigVersion
 }
 
 Client.prototype.apiCall = function (method, path, params, callback) {
@@ -21,7 +21,7 @@ Client.prototype.apiCall = function (method, path, params, callback) {
   }
   var body = ''
   var qs = querystring.stringify(params)
-  if (this.sig_version === 5) {
+  if (this.sigVersion === 5) {
     if (method === 'POST' || method === 'PUT') {
       body = JSON.stringify(params)
       params = {}

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,8 +4,10 @@ var querystring = require('querystring')
 var constants = require('./constants')
 
 const _PACKAGE_VERSION = require('../package.json').version
+const SIGNATURE_VERSION_2 = 2
+const SIGNATURE_VERSION_5 = 5
 
-function Client (ikey, skey, host, sigVersion = 2) {
+function Client (ikey, skey, host, sigVersion = SIGNATURE_VERSION_2) {
   this.ikey = ikey
   this.skey = skey
   this.host = host
@@ -20,9 +22,11 @@ Client.prototype.apiCall = function (method, path, params, callback) {
     'User-Agent': `duo_api_nodejs/${_PACKAGE_VERSION}`
   }
   var body = ''
+  var params_go_in_body = ['POST', 'PUT', 'PATCH'].includes(method)
   var qs = querystring.stringify(params)
-  if (this.sigVersion === 5) {
-    if (method === 'POST' || method === 'PUT') {
+
+  if (this.sigVersion === SIGNATURE_VERSION_5) {
+    if (params_go_in_body) {
       body = JSON.stringify(params)
       params = {}
     }
@@ -33,8 +37,13 @@ Client.prototype.apiCall = function (method, path, params, callback) {
       this.ikey, this.skey, method, this.host, path, params, date)
   }
 
-  if (method === 'POST' || method === 'PUT') {
-    headers['Content-type'] = 'application/json'
+  if (params_go_in_body) {
+    if (this.sigVersion === SIGNATURE_VERSION_5) {
+      headers['Content-Type'] = 'application/json'
+    } else {
+      headers['Content-Type'] = 'application/x-www-form-urlencoded'
+      body = qs
+    }
   } else if (qs) {
     path += '?' + qs
   }
@@ -84,5 +93,7 @@ Client.prototype.jsonApiCall = function (method, path, params, callback, signatu
 }
 
 module.exports = {
-  'Client': Client
+  'Client': Client,
+  'SIGNATURE_VERSION_2': SIGNATURE_VERSION_2,
+  'SIGNATURE_VERSION_5': SIGNATURE_VERSION_5
 }

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
         "eslint-plugin-standard": "^3.0.1",
         "mocha": "^5.2.0",
         "nock": "^9.6.1",
-        "sinon": "^7.2.7"
+        "sinon": "^7.2.7",
+        "chai": "~4.1.2"
     },
     "optionalDependencies": {
-        "nopt": ">= 2.1.2"
+        "nopt": "^2.1.2"
     },
-    "dependencies": {},
     "keywords": [
         "Duo Security",
         "Two-Factor Authentication"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@duosecurity/duo_api",
-    "version": "1.4.0",
+    "version": "1.3.0",
     "license": "BSD-3-Clause",
     "description": "Duo API SDK for Node.js applications",
     "homepage": "https://www.duosecurity.com/api",
@@ -27,9 +27,7 @@
     "optionalDependencies": {
         "nopt": ">= 2.1.2"
     },
-    "dependencies": {
-        "@duosecurity/duo_api": "^1.3.0"
-    },
+    "dependencies": {},
     "keywords": [
         "Duo Security",
         "Two-Factor Authentication"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@duosecurity/duo_api",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "license": "BSD-3-Clause",
     "description": "Duo API SDK for Node.js applications",
     "homepage": "https://www.duosecurity.com/api",
@@ -27,7 +27,9 @@
     "optionalDependencies": {
         "nopt": ">= 2.1.2"
     },
-    "dependencies": {},
+    "dependencies": {
+        "@duosecurity/duo_api": "^1.3.0"
+    },
     "keywords": [
         "Duo Security",
         "Two-Factor Authentication"

--- a/tests/duo_sig.js
+++ b/tests/duo_sig.js
@@ -112,3 +112,46 @@ describe('Query Parameter Checks', function () {
     done()
   })
 })
+
+describe('Signature Checks', function () {
+  it('V2 signature', function (done) {
+    var ikey = 'test_ikey'
+    var skey = 'test_skey'
+    var method = 'POST'
+    var host = 'test.duosecurity.com'
+    var path = '/test/v1'
+    var params = {
+      'realname': 'First Last',
+      'username': 'root'
+    }
+    var date = 'Tue, 21 Aug 2012 17:29:18 -0000'
+    var exp_sig = 'Basic dGVzdF9pa2V5OjA0MmEzMGM2ODJiZDgzNmZjNWJhNDY3ODkxYTk1NmVhYTEwMDkxY2EwZjczYTdmYjM5NmFlZmQ1NmEzNTI5ZTU2OTMyZGVhNDI3YTY3MjEzYWY2NjRiYTY4NDE2ODlmZjIzMzZiN2EzNzM3NjZlYTVhYjdhYjlmZTI2MzgyMjZi'
+
+    assert.equal(
+      duo_api.sign(ikey, skey, method, host, path, params, date),
+      exp_sig
+    )
+    done()
+  })
+
+  it('V5 signature', function (done) {
+    var ikey = 'test_ikey'
+    var skey = 'test_skey'
+    var method = 'POST'
+    var host = 'test.duosecurity.com'
+    var path = '/test/v1'
+    var params = {}
+    var date = 'Tue, 21 Aug 2012 17:29:18 -0000'
+    var exp_sig = 'Basic dGVzdF9pa2V5OjdkMDI0MDlhMTUyNzY0ODQzY2NjZDgyODRkYTE1M2IzZmI0NDZiYWFkNWY5OTg4ODYzMjVlMjRiYzljZDRhMjQ0ZGU4NWFkNGJmYTdlYTI4NWQ2ODIwOWYxNjA4MzU2NzNkOGI0ZjFlMWIyM2Q5Y2Q1MjFkMjZiZmU3ZjM2NmE0'
+    var body = JSON.stringify({
+      'realname': 'First Last',
+      'username': 'root'
+    })
+
+    assert.equal(
+      duo_api.signV5(ikey, skey, method, host, path, params, date, body),
+      exp_sig
+    )
+    done()
+  })
+})

--- a/tests/main.js
+++ b/tests/main.js
@@ -68,7 +68,6 @@ describe('Verifying rate limited request retries', function () {
     rateLimitedScope.on('replied', function (req, interceptor) {
       clock.tick(currentWaitSecs + MAX_RANDOM_OFFSET)
     })
-    console.log('added emitter')
   })
 
   it('verify all rate limited responses', function (done) {
@@ -115,11 +114,9 @@ describe('Signature Checks', function () {
     var scope = setupNock(requestHeaders)
     scope.get(/.*/)
       .reply(200, {'response': {foo: 'bar'}, stat: 'OK'})
-      .log(console.log)
 
     var client = new duo_api.Client(IKEY, SKEY, API_HOSTNAME)
     client.jsonApiCall('GET', '/foo/bar', params, function (resp) {
-      console.log(resp)
       assert.equal(resp.stat, 'OK')
       done()
     })
@@ -139,11 +136,9 @@ describe('Signature Checks', function () {
     var scope = setupNock(requestHeaders)
     scope.post(/.*/)
       .reply(200, {'response': {foo: 'bar'}, stat: 'OK'})
-      .log(console.log)
 
     var client = new duo_api.Client(IKEY, SKEY, API_HOSTNAME)
     client.jsonApiCall('POST', '/foo/bar', params, function (resp) {
-      console.log(resp)
       assert.equal(resp.stat, 'OK')
       done()
     })
@@ -163,11 +158,9 @@ describe('Signature Checks', function () {
     var scope = setupNock(requestHeaders)
     scope.get(/.*/)
       .reply(200, {'response': {foo: 'bar'}, stat: 'OK'})
-      .log(console.log)
 
-    var client = new duo_api.Client(IKEY, SKEY, API_HOSTNAME, duo_api.SIG_VERSION_5)
+    var client = new duo_api.Client(IKEY, SKEY, API_HOSTNAME, duo_api.SIGNATURE_VERSION_5)
     client.jsonApiCall('GET', '/foo/bar', params, function (resp) {
-      console.log(resp)
       assert.equal(resp.stat, 'OK')
       done()
     })
@@ -182,17 +175,15 @@ describe('Signature Checks', function () {
     var requestHeaders = {
       'Date': date,
       'Host': API_HOSTNAME,
-      //'Authorization': sig,
+      'Authorization': sig,
       'Content-type': 'application/json'
     }
     var scope = setupNock(requestHeaders)
     scope.post(/.*/)
       .reply(200, {'response': {foo: 'bar'}, stat: 'OK'})
-      .log(console.log)
 
-    var client = new duo_api.Client(IKEY, SKEY, API_HOSTNAME, duo_api.SIG_VERSION_5)
+    var client = new duo_api.Client(IKEY, SKEY, API_HOSTNAME, duo_api.SIGNATURE_VERSION_5)
     client.jsonApiCall('POST', '/foo/bar', params, function (resp) {
-      console.log(resp)
       assert.equal(resp.stat, 'OK')
       done()
     })


### PR DESCRIPTION
## Description
Adds a new field to `jsonApiCall` to support v5 signatures. Also adds a new example file showing how to call Policy API endpoints.

## Motivation and Context
We've received requests to add support for Policy Admin API endpoints with the Node.js client.

## How Has This Been Tested?
Added new test file, verified that existing calls did not break.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
